### PR TITLE
Fix table columns ordering

### DIFF
--- a/PwshSpectreConsole/public/PwshSpectreConsole.ps1
+++ b/PwshSpectreConsole/public/PwshSpectreConsole.ps1
@@ -378,21 +378,25 @@ function Format-SpectreTable {
     }
     process {
         if(!$headerProcessed) {
-            $data[0].psobject.Properties.Name | Foreach-Object {
+            $Data[0].psobject.Properties.Name | Foreach-Object {
                 $table.AddColumn($_) | Out-Null
             }
             
             $headerProcessed = $true
         }
-        $row = @()
-        $Data | Get-Member -MemberType Properties | Foreach-Object {
-            if($null -eq $Data."$($_.Name)") {
-                $row += [Spectre.Console.Text]::new("")
-            } else {
-                $row += [Spectre.Console.Text]::new($Data."$($_.Name)".ToString())
+        $Data | Foreach-Object {
+            $row = @()
+            $_.psobject.Properties | ForEach-Object {
+                $cell = $_.Value
+                if ($null -eq $cell) {
+                    $row += [Spectre.Console.Text]::new("")
+                }
+                else {
+                    $row += [Spectre.Console.Text]::new($cell.ToString())
+                }
             }
+            $table = [Spectre.Console.TableExtensions]::AddRow($table, [Spectre.Console.Text[]]$row)
         }
-        $table = [Spectre.Console.TableExtensions]::AddRow($table, [Spectre.Console.Text[]]$row)
     }
     end {
         [Spectre.Console.AnsiConsole]::Write($table)


### PR DESCRIPTION
### Fix bug in **Format-SpectreTable** function
#### Bug description
Table headers ordered as in input object, but table columns ordered alphabetically as returned by **Get-Member -MemberType Properties**

#### Reproduce bug
``` powershell
$json = @'
[
    {
        "Nums": 1,
        "Letters": "a"
    },
    {
        "Nums": 2,
        "Letters": "b"
    }
]
'@

$json | ConvertFrom-Json
<# Correct data columns order
Nums Letters
---- -------
   1 a
   2 b
#>

$json | ConvertFrom-Json | Format-SpectreTable
<# Format-SpectreTable returns data columns in incorrect order
╔══════╦═════════╗
║ Nums ║ Letters ║
╠══════╬═════════╣
║ a    ║ 1       ║
║ b    ║ 2       ║
╚══════╩═════════╝
#>

$json | ConvertFrom-Json | Get-Member -MemberType Properties
<# Get-Member commandlet returns properties ordered by Name
Name    MemberType   Definition
----    ----------   ----------
Letters NoteProperty string Letters=a
Nums    NoteProperty long Nums=1
#>

```

#### Fix bug
- Create array of cells from each input row
- Add rows to table one by one
