### PR TITLE
Update Read-SpectreMultiSelection.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pnpm-debug.log*
 
 # Exclude packages folder
 PwshSpectreConsole/packages
+
+# Exclude working folder
+Working/

--- a/PwshSpectreConsole/public/prompts/Read-SpectreMultiSelection.ps1
+++ b/PwshSpectreConsole/public/prompts/Read-SpectreMultiSelection.ps1
@@ -36,7 +36,7 @@ function Read-SpectreMultiSelection {
         [ArgumentCompletionsSpectreColors()]
         [string] $Color = $script:AccentColor.ToMarkup(),
         [int] $PageSize = 5,
-        [switch] $AllowEmpty
+        [switch] $RequireChoice
     )
     $spectrePrompt = [Spectre.Console.MultiSelectionPrompt[string]]::new()
 
@@ -55,7 +55,7 @@ function Read-SpectreMultiSelection {
     $spectrePrompt.Title = $Title
     $spectrePrompt.PageSize = $PageSize
     $spectrePrompt.WrapAround = $true
-    $spectrePrompt.AllowEmpty = $AllowEmpty
+    $spectrePrompt.Required = $RequireChoice
     $spectrePrompt.HighlightStyle = [Spectre.Console.Style]::new(($Color | Convert-ToSpectreColor))
     $spectrePrompt.InstructionsText = "[$($script:DefaultValueColor.ToMarkup())](Press [$($script:AccentColor.ToMarkup())]space[/] to toggle a choice and press [$($script:AccentColor.ToMarkup())]<enter>[/] to submit your answer)[/]"
     $spectrePrompt.MoreChoicesText = "[$($script:DefaultValueColor.ToMarkup())](Move up and down to reveal more choices)[/]"

--- a/PwshSpectreConsole/public/prompts/Read-SpectreMultiSelection.ps1
+++ b/PwshSpectreConsole/public/prompts/Read-SpectreMultiSelection.ps1
@@ -23,6 +23,9 @@ function Read-SpectreMultiSelection {
     .PARAMETER PageSize
     The number of choices to display per page. Defaults to 5.
 
+    .PARAMETER AllowEmpty
+    Allow the multi-selection to be submitted without any options chosen.
+
     .EXAMPLE
     # Displays a multi-selection prompt with the title "Select your favourite fruits", the list of fruits, the "Name" property as the label for each fruit, the color green for highlighting the selected fruits, and 3 fruits per page.
     Read-SpectreMultiSelection -Title "Select your favourite fruits" -Choices @("apple", "banana", "orange", "pear", "strawberry") -Color "Green" -PageSize 3
@@ -36,7 +39,7 @@ function Read-SpectreMultiSelection {
         [ArgumentCompletionsSpectreColors()]
         [string] $Color = $script:AccentColor.ToMarkup(),
         [int] $PageSize = 5,
-        [switch] $RequireChoice
+        [switch] $AllowEmpty
     )
     $spectrePrompt = [Spectre.Console.MultiSelectionPrompt[string]]::new()
 
@@ -55,7 +58,7 @@ function Read-SpectreMultiSelection {
     $spectrePrompt.Title = $Title
     $spectrePrompt.PageSize = $PageSize
     $spectrePrompt.WrapAround = $true
-    $spectrePrompt.Required = $RequireChoice
+    $spectrePrompt.Required = !$AllowEmpty
     $spectrePrompt.HighlightStyle = [Spectre.Console.Style]::new(($Color | Convert-ToSpectreColor))
     $spectrePrompt.InstructionsText = "[$($script:DefaultValueColor.ToMarkup())](Press [$($script:AccentColor.ToMarkup())]space[/] to toggle a choice and press [$($script:AccentColor.ToMarkup())]<enter>[/] to submit your answer)[/]"
     $spectrePrompt.MoreChoicesText = "[$($script:DefaultValueColor.ToMarkup())](Move up and down to reveal more choices)[/]"

--- a/PwshSpectreConsole/public/prompts/Read-SpectreMultiSelectionGrouped.ps1
+++ b/PwshSpectreConsole/public/prompts/Read-SpectreMultiSelectionGrouped.ps1
@@ -23,6 +23,9 @@ function Read-SpectreMultiSelectionGrouped {
     .PARAMETER PageSize
     The number of choices to display per page. The default value is 10.
 
+    .PARAMETER AllowEmpty
+    Allow the multi-selection to be submitted without any options chosen.
+
     .EXAMPLE
     # This example displays a multi-selection prompt with two groups of choices: "Primary Colors" and "Secondary Colors". The prompt uses the "Name" property of each choice as the label. The user can select one or more choices from each group.
     Read-SpectreMultiSelectionGrouped -Title "Select your favorite colors" -Choices @(


### PR DESCRIPTION
Fixed AllowEmpty parameter being assigned to a non-existent property of the [MultiSelectionPromptExtensions] class.