### PR TITLE
Add choices to Read-SpectraText

### DIFF
--- a/PwshSpectreConsole/public/prompts/Read-SpectreText.ps1
+++ b/PwshSpectreConsole/public/prompts/Read-SpectreText.ps1
@@ -32,7 +32,8 @@ function Read-SpectreText {
         [ValidateSpectreColor()]
         [ArgumentCompletionsSpectreColors()]
         [string] $AnswerColor,
-        [switch] $AllowEmpty
+        [switch] $AllowEmpty,
+        [string[]] $Choices
     )
     $spectrePrompt = [Spectre.Console.TextPrompt[string]]::new($Question)
     $spectrePrompt.DefaultValueStyle = [Spectre.Console.Style]::new($script:DefaultValueColor)
@@ -43,5 +44,9 @@ function Read-SpectreText {
         $spectrePrompt.PromptStyle = [Spectre.Console.Style]::new(($AnswerColor | Convert-ToSpectreColor))
     }
     $spectrePrompt.AllowEmpty = $AllowEmpty
+    if ($null -ne $Choices)
+    {
+        $spectrePrompt = [Spectre.Console.TextPromptExtensions]::AddChoices($spectrePrompt, $Choices)
+    }
     return Invoke-SpectrePromptAsync -Prompt $spectrePrompt
 }


### PR DESCRIPTION
Add the missing Choices parameter to Read-SpectraText.

Usage:
`Read-SpectreText -Question "Really?" -DefaultAnswer "y" -Choices @('y', 'n')`

Appears:
`Really? [y/n] (y):`