### PR TITLE
Get-SpectreImage improvements fixes #67

### DIFF
--- a/PwshSpectreConsole/PwshSpectreConsole.psm1
+++ b/PwshSpectreConsole/PwshSpectreConsole.psm1
@@ -23,6 +23,9 @@ foreach ($directory in @('private', 'public')) {
     }
 }
 
+# cache the DA1 response.
+$script:TerminalSupportsSixel = Test-SpectreSixelSupport
+
 $script:SpectreProfile = Get-SpectreProfile
 if ($script:SpectreProfile.Unicode -eq $true -or $env:IgnoreSpectreConsoleEncoding) {
     return $script:SpectreConsole

--- a/PwshSpectreConsole/private/Get-ControlSequenceResponse.ps1
+++ b/PwshSpectreConsole/private/Get-ControlSequenceResponse.ps1
@@ -18,11 +18,11 @@ function Get-ControlSequenceResponse {
         [Parameter(Mandatory)]
         [string] $ControlSequence
     )
-    $response = ""
-    Write-Host -NoNewline "`e$ControlSequence"
-    do {
-        $c = [Console]::ReadKey($true).KeyChar
-        $response += $c
-    } while ($c -ne "c" -and [Console]::KeyAvailable)
-    return $response
+    $char = $null
+    [console]::Write([char]27 + $ControlSequence)
+    $response = do {
+            $char = [console]::ReadKey($true).KeyChar
+            $char
+        } while ($char -ne 'c' -and [Console]::KeyAvailable)
+    return -join $response
 }

--- a/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
+++ b/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
@@ -6,11 +6,11 @@ function Get-SpectreImage {
     Displays an image in the console using CanvasImage or SixelImage if the terminal supports Sixel.
 
     .DESCRIPTION
-    Displays an image in the console using CanvasImage or SixelImage if the terminal supports Sixel.  
-    The image can be resized to a maximum width if desired.  
+    Displays an image in the console using CanvasImage or SixelImage if the terminal supports Sixel.
+    The image can be resized to a maximum width if desired.
 
-    Windows Terminal supports Sixel in the [latest preview builds](https://apps.microsoft.com/detail/9n8g5rfz9xk3) so it will be available in the production builds soon 🤞  
-    See https://www.arewesixelyet.com/ for Sixel support status for your terminal.  
+    Windows Terminal supports Sixel in the [latest preview builds](https://apps.microsoft.com/detail/9n8g5rfz9xk3) so it will be available in the production builds soon 🤞
+    See https://www.arewesixelyet.com/ for Sixel support status for your terminal.
 
     .PARAMETER ImagePath
     The path to the image file to be displayed, as a local path or remote path using http/https.
@@ -19,20 +19,23 @@ function Get-SpectreImage {
     The maximum width of the image. If not specified, the image will be displayed at its original size.
 
     .PARAMETER Format
-    The preferred format to use when rendering the image.  
+    The preferred format to use when rendering the image.
     If not specified, the image will be rendered using Sixel if the terminal supports it, otherwise it will use Canvas.
 
+    .PARAMETER Force
+    Forces the image to be displayed using the specified format, even if we can't detect Sixel support in the terminal.
+
     .EXAMPLE
-    # **Example 1**  
+    # **Example 1**
     # When Sixel is not supported the image will use the standard Canvas renderer which draws the image using character cells to represent the image.
     Get-SpectreImage -ImagePath ".\private\images\smiley.png" -MaxWidth 40
 
     .EXAMPLE
-    # **Example 2**  
-    # For Sixel images, the image returned by `Get-SpectreImage` will render a new frame every time it's drawn so if it's an animated GIF it will appear animated if you render it repeatedly and move the cursor back to the same start position before each image output.  
-    #   
+    # **Example 2**
+    # For Sixel images, the image returned by `Get-SpectreImage` will render a new frame every time it's drawn so if it's an animated GIF it will appear animated if you render it repeatedly and move the cursor back to the same start position before each image output.
+    #
     # ![Spectre Sixel Example](/lapras-terminal.gif)
-    #   
+    #
     NORECORDING
     $image = Get-SpectreImage ".\private\images\lapras-pokemon.gif" -MaxWidth 50
 
@@ -45,49 +48,55 @@ function Get-SpectreImage {
         Start-Sleep -Milliseconds 150
     }
     #>
-    [Reflection.AssemblyMetadata("title", "Get-SpectreImage")]
+    [Reflection.AssemblyMetadata('title', 'Get-SpectreImage')]
+    [CmdletBinding()]
     param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        [Alias('Uri', 'FullName')]
         [string] $ImagePath,
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [Alias('Width')]
         [int] $MaxWidth,
-        [ValidateSet("Auto", "Sixel", "Canvas")]
-        [string] $Format = "Auto"
+        [ValidateSet('Auto', 'Sixel', 'Canvas')]
+        [string] $Format = 'Auto',
+        [switch] $Force
     )
-
-    if ($ImagePath.StartsWith("http://") -or $ImagePath.StartsWith("https://")) {
-        if (!$script:CachedImages.ContainsKey($ImagePath) -or -not (Test-Path $script:CachedImages[$ImagePath])) {
-            $tempFile = New-TemporaryFile
-            Invoke-WebRequest -Uri $ImagePath -UseBasicParsing -Outfile $tempFile -ProgressAction SilentlyContinue
-            $script:CachedImages[$ImagePath] = $tempFile.FullName
+    process {
+        if ($ImagePath.StartsWith('http://') -or $ImagePath.StartsWith('https://')) {
+            if (!$script:CachedImages.ContainsKey($ImagePath) -or -not (Test-Path $script:CachedImages[$ImagePath])) {
+                $tempFile = New-TemporaryFile
+                Invoke-WebRequest -Uri $ImagePath -UseBasicParsing -OutFile $tempFile -ProgressAction SilentlyContinue
+                $script:CachedImages[$ImagePath] = $tempFile.FullName
+            }
+            $ImagePath = $script:CachedImages[$ImagePath]
         }
-        $ImagePath = $script:CachedImages[$ImagePath]
-    }
 
-    $imagePathResolved = Resolve-Path $ImagePath
-    if (-not (Test-Path $imagePathResolved)) {
-        throw "The specified image path '$resolvedImagePath' does not exist."
-    }
+        $imagePathResolved = Resolve-Path $ImagePath
+        if (-not (Test-Path $imagePathResolved)) {
+            throw "The specified image path '$resolvedImagePath' does not exist."
+        }
 
-    $image = $null
-    if ($Format -eq "Auto") {
-        if (Test-SpectreSixelSupport) {
-            $image = [Spectre.Console.SixelImage]::new($imagePathResolved)
-        } else {
+        $image = $null
+        if ($Format -eq 'Auto') {
+            if ($script:TerminalSupportsSixel -or $Force.IsPresent) {
+                $image = [Spectre.Console.SixelImage]::new($imagePathResolved)
+            } else {
+                $image = [Spectre.Console.CanvasImage]::new($imagePathResolved)
+            }
+        } elseif ($Format -eq 'Sixel') {
+            if ($script:TerminalSupportsSixel -or $Force.IsPresent) {
+                $image = [Spectre.Console.SixelImage]::new($imagePathResolved)
+            } else {
+                throw 'Sixel format is not supported in this terminal.'
+            }
+        } elseif ($Format -eq 'Canvas') {
             $image = [Spectre.Console.CanvasImage]::new($imagePathResolved)
         }
-    } elseif ($Format -eq "Sixel") {
-        if (Test-SpectreSixelSupport) {
-            $image = [Spectre.Console.SixelImage]::new($imagePathResolved)
-        } else {
-            throw "Sixel format is not supported in this terminal."
-        }
-    } elseif ($Format -eq "Canvas") {
-        $image = [Spectre.Console.CanvasImage]::new($imagePathResolved)
-    }
 
-    if ($MaxWidth) {
-        $image.MaxWidth = $MaxWidth
+        if ($MaxWidth) {
+            $image.MaxWidth = $MaxWidth
+        }
+
+        $image
     }
-    
-    return $image
 }


### PR DESCRIPTION
* add pipeline support to Get-SpectreImage
* tweak the DA1 check, the old one got stuck waiting on input sometimes. 
* cache the DA1 results.
* allow override of Sixel detection with -Force

fixes #67 
