### PR TITLE
fix(PSDrives): ✏️ Get-SpectreImage fails on PSDrives #88

### DIFF
--- a/PwshSpectreConsole/private/completions/Completers.psm1
+++ b/PwshSpectreConsole/private/completions/Completers.psm1
@@ -12,7 +12,7 @@ class ArgumentCompletionsSpectreColors : ArgumentCompleterAttribute {
             foreach ($Color in ([Spectre.Console.Color] | Get-Member -Static -Type Properties).Name) {
                 if ($Color -like "$wordToComplete*") {
                     [CompletionResult]::new(
-                        <# completionText #> [Spectre.Console.Color]::$Color,
+                        <# completionText #> $Color,
                         <# listItemText #>   ([Spectre.Console.Markup]::new($Color, [Spectre.Console.Style]::new([Spectre.Console.Color]::$Color)) | Out-SpectreHost),
                         <# resultType #>     'ParameterValue',
                         <# toolTip #>        $Color

--- a/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
+++ b/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
@@ -72,7 +72,8 @@ function Get-SpectreImage {
         }
 
         $imagePathResolved = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($ImagePath)
-        if (-not (Test-Path $imagePathResolved)) {
+        if (-not (Test-Path -Path $imagePathResolved -PathType Leaf)) {
+            # more explicit test for file, otherwise it passes for directories.
             throw "The specified image path '$imagePathResolved' does not exist."
         }
 

--- a/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
+++ b/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
@@ -73,7 +73,7 @@ function Get-SpectreImage {
 
         $imagePathResolved = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($ImagePath)
         if (-not (Test-Path $imagePathResolved)) {
-            throw "The specified image path '$resolvedImagePath' does not exist."
+            throw "The specified image path '$imagePathResolved' does not exist."
         }
 
         $image = $null

--- a/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
+++ b/PwshSpectreConsole/public/images/Get-SpectreImage.ps1
@@ -26,12 +26,12 @@ function Get-SpectreImage {
     Forces the image to be displayed using the specified format, even if we can't detect Sixel support in the terminal.
 
     .EXAMPLE
-    # **Example 1**  
+    # **Example 1**
     # When Sixel is not supported the image will use the standard Canvas renderer which draws the image using character cells to represent the image.
     Get-SpectreImage -ImagePath ".\private\images\smiley.png" -MaxWidth 40
 
     .EXAMPLE
-    # **Example 2**  
+    # **Example 2**
     # For Sixel images, the image returned by `Get-SpectreImage` will render a new frame every time it's drawn so if it's an animated GIF it will appear animated if you render it repeatedly and move the cursor back to the same start position before each image output.
     #
     # ![Spectre Sixel Example](/lapras-terminal.gif)
@@ -71,7 +71,7 @@ function Get-SpectreImage {
             $ImagePath = $script:CachedImages[$ImagePath]
         }
 
-        $imagePathResolved = Resolve-Path $ImagePath
+        $imagePathResolved = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($ImagePath)
         if (-not (Test-Path $imagePathResolved)) {
             throw "The specified image path '$resolvedImagePath' does not exist."
         }


### PR DESCRIPTION
* fixes #88 , Get-SpectreImage correctly resolves PSDrives
* Updated the color completion, minor fix

![image](https://github.com/user-attachments/assets/c8577cf8-42bd-4fc8-9b74-452ac1bb25a2)
