### PR TITLE
Wait-SpectreJobs Fix for NotRunning

### DIFF
--- a/PwshSpectreConsole/public/live/Wait-SpectreJobs.ps1
+++ b/PwshSpectreConsole/public/live/Wait-SpectreJobs.ps1
@@ -57,7 +57,9 @@ function Wait-SpectreJobs {
         }
         $completedJobs = 0
         foreach ($job in $Jobs) {
-            if ($job.Job.State -ne "Running") {
+            # JobState is an Enum. Anything less then 2 (NotStarted, Running) is not 100%
+            # https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.jobstate?view=powershellsdk-7.4.0
+            if ([int][System.Management.Automation.JobState]$job.Job.State -gte 2) {
                 $job.Task.Value = 100.0
                 $completedJobs++
                 continue

--- a/PwshSpectreConsole/public/live/Wait-SpectreJobs.ps1
+++ b/PwshSpectreConsole/public/live/Wait-SpectreJobs.ps1
@@ -57,9 +57,9 @@ function Wait-SpectreJobs {
         }
         $completedJobs = 0
         foreach ($job in $Jobs) {
-            # JobState is an Enum. Anything less then 2 (NotStarted, Running) is not 100%
+            # JobState is an Enum. Anything less than [System.Management.Automation.JobState]::Completed (NotStarted, Running) is not 100%
             # https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.jobstate?view=powershellsdk-7.4.0
-            if ([int][System.Management.Automation.JobState]$job.Job.State -gte 2) {
+            if ([System.Management.Automation.JobState]$job.Job.State -ge [System.Management.Automation.JobState]::Completed) {
                 $job.Task.Value = 100.0
                 $completedJobs++
                 continue


### PR DESCRIPTION
This takes the `$job.Job.State` object and casts it back into a `JobState` enum. From there we can convert the enum value back into an int and use a simple greater than or equals comparison.

It may be easier to understand if we have a list of values but this should be future proof (famous last words). It's highly unlikely they would prepend the current enum list.

Fixes #103 