### PR TITLE
Add ShowRowSeparators to Table properties

### DIFF
--- a/PwshSpectreConsole/public/formatting/Format-SpectreTable.ps1
+++ b/PwshSpectreConsole/public/formatting/Format-SpectreTable.ps1
@@ -49,6 +49,9 @@ function Format-SpectreTable {
     .PARAMETER Title
     The title of the table.
 
+    .PARAMETER ShowRowSeparators
+    Shows row separators.
+
     .PARAMETER AllowMarkup
     Allow Spectre markup in the table elements e.g. [green]message[/].
 
@@ -132,6 +135,7 @@ function Format-SpectreTable {
         [int] $Width,
         [switch] $HideHeaders,
         [String] $Title,
+        [switch] $ShowRowSeparators,
         [switch] $AllowMarkup,
         [switch] $Expand
     )
@@ -149,6 +153,7 @@ function Format-SpectreTable {
             'Width' { $table.Width = $Width }
             'HideHeaders' { $table.ShowHeaders = $false }
             'Title' { $tableoptions.Title = $Title }
+            'ShowRowSeparators' { [Spectre.Console.TableExtensions]::ShowRowSeparators($table) | Out-Null }
             'AllowMarkup' { $rowoptions.AllowMarkup = $true }
             'Wrap' { $tableoptions.Wrap = $true ; $FormatTableParams.Wrap = $true }
             'View' { $FormatTableParams.View = $View }


### PR DESCRIPTION
Added switch parameter in Format-SpectreTable function to show table row separators.  See [ShowRowSeparators](https://spectreconsole.net/api/spectre.console/tableextensions/2c237104).

Example:
<img width="2096" height="1035" alt="image" src="https://github.com/user-attachments/assets/155b3f4e-1371-467b-9421-0e4e6802cd67" />
